### PR TITLE
Detect XML and shell scripts via special patterns

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 
 {{$NEXT}}
+- Detect XML files and shell scripts via File::MMagic Specials patterns
 
 0.02   2023-09-26
 - Rewind filehandles after determining type

--- a/lib/Catalyst/Plugin/CheckFileUploadTypes.pm
+++ b/lib/Catalyst/Plugin/CheckFileUploadTypes.pm
@@ -43,6 +43,13 @@ sub dispatch {
     
     my $mm = File::MMagic->new;
 
+    # Detect XML files by opening <?xml tag
+    $mm->addSpecials('text/xml', qr{^<\?xml}i);
+
+    # Detect shell scripts by opening shebang:
+    $mm->addSpecials('text/x-shellscript', qr{^#\!}i);
+
+
     my $expects_uploads = $action->attributes->{ExpectUploads};
 
     my %ok_type;

--- a/t/data/notshell.txt
+++ b/t/data/notshell.txt
@@ -1,0 +1,12 @@
+This file is not a shell script, but contains an example of one in the
+middle, to make sure we don't falsely detect it.
+
+Here's our shell script:
+
+```sh
+#!/bin/bash
+
+echo "Example shell script"
+```
+
+Clearly this file isn't a shell script itself, so should be left alone.

--- a/t/data/shell.sh
+++ b/t/data/shell.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Safe shell script"
+

--- a/t/data/test.xml
+++ b/t/data/test.xml
@@ -1,0 +1,4 @@
+<?xml>
+<Foo>
+    <Bar>One</Bar>
+</Foo>

--- a/t/lib/TestApp/Controller/Root.pm
+++ b/t/lib/TestApp/Controller/Root.pm
@@ -26,6 +26,10 @@ sub expect_image :Local :Args(0) ExpectUploads(image/png) {
     $c->response->body("Hit expect_image");
 }
 
+sub expect_text :Local :Args(0) ExpectUploads(text/plain) {
+    my ($self, $c) = @_;
+    $c->response->body("Hit expect_text");
+}
 
 __PACKAGE__->meta->make_immutable;
 


### PR DESCRIPTION
By default, [File::MMagic][1] will return `text/plain` for an XML file even if it starts with an `<?xml...` processing directive, and also for a shell script, even if it starts with a shebang.

Add special patterns via File::MMagic's `addSpecials()` to detect these.

[1]: https://metacpan.org/pod/File::MMagic
